### PR TITLE
Fedora tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-language: python
-python:
-  - "3.6"
-install:
-  - pip install -r requirements.txt
+sudo: required
+language: bash
+services:
+  - docker
+
+before_install:
+  - docker build -f Dockerfile.test -t release-bot-test .
+
 script:
-  - make travis
+  - docker run -it release-bot-test

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,27 @@
+FROM registry.fedoraproject.org/fedora:27
+
+RUN dnf install -y python3 python2 python-pip fedpkg git \
+    python3-pytest make
+
+ENV HOME=/usr/src/app
+
+RUN mkdir -p ${HOME} && \
+	useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
+    -c "Default Application User" default
+
+WORKDIR ${HOME}
+
+COPY . ${HOME}
+
+RUN pip3 install -r requirements.txt && \
+    pip2 install wheel && \
+    chown -R 1001:0 ${HOME}
+
+USER 1001
+
+RUN git config --global user.email "jdoe@example.com" && \
+    git config --global user.name "John Doe"
+
+
+CMD make test
+

--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@
 test:
 	PYTHONPATH=$(CURDIR) pytest-3 tests/
 
-travis:
-	if [ $(TRAVIS_PYTHON_VERSION) = 3.6 ]; then PYTHONPATH=$(CURDIR) pytest tests/ --ignore tests/test_pypi_2.py; else PYTHONPATH=$(CURDIR) pytest tests/ --ignore tests/test_pypi_3.py;fi
+clean:
+	find . -name '*.pyc' -delete

--- a/tests/src/example.spec
+++ b/tests/src/example.spec
@@ -7,6 +7,9 @@ License: 		GPLv3+
 URL:			www.example.com
 Source0:        www.example.com
 
+%description
+Example description
+
 %changelog
 * Wed Dec 06 2017 John Doe <jdoe@example.com> - 0.0.1-2
 - Initial package.

--- a/tests/src/example_updated.spec
+++ b/tests/src/example_updated.spec
@@ -7,6 +7,9 @@ License: 		GPLv3+
 URL:			www.example.com
 Source0:        www.example.com
 
+%description
+Example description
+
 %changelog
 * Mon Dec 24 2018 John Doe <jdoe@example.com> 0.0.2-1
 - 0.0.2 release

--- a/tests/src/example_updated_changelog.spec
+++ b/tests/src/example_updated_changelog.spec
@@ -7,6 +7,9 @@ License: 		GPLv3+
 URL:			www.example.com
 Source0:        www.example.com
 
+%description
+Example description
+
 %changelog
 * Mon Dec 24 2018 John Doe <jdoe@example.com> 0.0.2-1
 - Changelog entry 1

--- a/tests/test_fedora.py
+++ b/tests/test_fedora.py
@@ -1,0 +1,301 @@
+import os
+import sys
+import release_bot.release_bot as release_bot
+from release_bot.release_bot import tempfile
+import pytest
+import subprocess
+from flexmock import flexmock
+
+
+class TestFedora:
+
+    def run_cmd(self, cmd, work_directory):
+        shell = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True,
+            cwd=work_directory,
+            universal_newlines=True)
+        return shell
+
+    def setup_method(self, method):
+        """ setup any state tied to the execution of the given method in a
+        class.  setup_method is invoked for every test method of a class.
+        """
+        release_bot.CONFIGURATION['logger'] = release_bot.set_logging(level=10)
+        release_bot.CONFIGURATION['debug'] = True
+
+    def teardown_method(self, method):
+        """ teardown any state that was previously setup with a setup_method
+        call.
+        """
+
+    def fake_spectool_func(self, directory, branch, fail=True):
+        source_path = os.path.join(directory, f"{branch}_source.tar.gz")
+        with open(source_path, "w") as file:
+            file.write("Stuff")
+        return True
+
+    def fake_clone_func(self, directory, name):
+        if os.path.isdir(directory):
+            release_bot.shell_command(directory,
+                                      f"fedpkg clone {name!r} -a",
+                                      "Cloning fedora repository failed:")
+            return os.path.join(directory, name)
+        else:
+            release_bot.CONFIGURATION['logger'].error(f"Cannot clone fedpkg repository into non-existent directory:")
+            sys.exit(1)
+
+    def fake_repository_clone_func(self, directory, name, non_ff=False):
+        self.create_fake_repository(directory, non_ff)
+        return directory
+
+    def create_fake_repository(self, directory, non_ff=False):
+        self.run_cmd("git init .", directory)
+        self.run_cmd("git checkout -b master", directory)
+        filename = os.path.join(directory, "example.spec")
+        with open(os.path.join(os.path.dirname(__file__), "src/example.spec")) as file:
+            with open(filename, "w") as new_file:
+                new_file.write(file.read())
+        self.run_cmd("git add .", directory)
+        self.run_cmd("git commit -m 'Initial commit'", directory)
+        self.run_cmd("git checkout -b f28", directory)
+        if non_ff:
+            with open(os.path.join(os.path.dirname(__file__), "src/example_updated.spec")) as file:
+                with open(filename, "w") as new_file:
+                    new_file.write(file.read())
+            self.run_cmd("git add .", directory)
+            self.run_cmd("git commit -m 'Initial commit 2'", directory)
+        else:
+            self.run_cmd("git merge master", directory)
+        self.run_cmd("git checkout master", directory)
+
+    @pytest.fixture
+    def new_release(self):
+        new_release = {'version': '9.9.9',
+                       'commitish': '',
+                       'author_name': 'John Doe',
+                       'author_email': 'jdoe@example.com',
+                       'python_versions': [3],
+                       'fedora_branches': ["f28"],
+                       'fedora': True,
+                       'changelog': ['Test'],
+                       'fs_path': '',
+                       'tempdir': None}
+        return new_release
+
+    @pytest.fixture()
+    def no_sources(self):
+        flexmock(release_bot, fedpkg_sources=True)
+
+    @pytest.fixture()
+    def no_build(self):
+        flexmock(release_bot, fedpkg_build=True)
+
+    @pytest.fixture()
+    def no_push(self):
+        flexmock(release_bot, fedpkg_push=True)
+
+    @pytest.fixture()
+    def no_new_sources(self):
+        flexmock(release_bot, fedpkg_new_sources=True)
+
+    @pytest.fixture()
+    def fake_spectool(self):
+        (flexmock(release_bot)
+         .should_receive("fedpkg_spectool")
+         .replace_with(lambda directory, branch, fail: self.fake_spectool_func(directory, branch, fail)))
+
+    @pytest.fixture
+    def fake_repository_clone(self, tmpdir):
+        (flexmock(release_bot)
+         .should_receive("fedpkg_clone_repository")
+         .replace_with(lambda directory, name: self.fake_repository_clone_func(tmpdir, name)))
+        return tmpdir
+
+    @pytest.fixture
+    def fake_repository_clone_no_ff(self, tmpdir):
+        (flexmock(release_bot)
+         .should_receive("fedpkg_clone_repository")
+         .replace_with(lambda directory, name: self.fake_repository_clone_func(tmpdir, name, True)))
+        return tmpdir
+
+    @pytest.fixture
+    def fake_clone(self):
+        (flexmock(release_bot)
+         .should_receive("fedpkg_clone_repository")
+         .replace_with(lambda directory, name: self.fake_clone_func(directory, name)))
+
+    @pytest.fixture
+    def no_lint(self):
+        flexmock(release_bot, fedpkg_lint=True)
+
+    @pytest.fixture
+    def fake_tmp_clean(self):
+        (flexmock(release_bot.tempfile.TemporaryDirectory)
+         .should_receive("cleanup")
+         .replace_with(lambda: None))
+
+    @pytest.fixture
+    def package(self):
+        return 'fedpkg'
+
+    @pytest.fixture
+    def non_existent_path(self, tmpdir):
+        path = os.path.join(tmpdir, 'foo')
+        return path
+
+    @pytest.fixture
+    def tmp(self, tmpdir):
+        return tmpdir
+
+    @pytest.fixture
+    def fake_repository(self, tmpdir):
+        self.create_fake_repository(tmpdir)
+        return tmpdir
+
+    @pytest.fixture
+    def example_spec(self, tmpdir):
+        spec = tmpdir.join("example.spec")
+        with open(os.path.join(os.path.dirname(__file__), "src/example.spec")) as file:
+            spec.write(file.read())
+        return spec
+
+    def test_wrong_dir_clone(self, non_existent_path, package, fake_clone):
+        with pytest.raises(SystemExit) as error:
+            release_bot.fedpkg_clone_repository(non_existent_path, package)
+        assert error.type == SystemExit
+        assert error.value.code == 1
+
+    def test_wrong_dir_switch(self, non_existent_path):
+        with pytest.raises(SystemExit) as error:
+            release_bot.fedpkg_switch_branch(non_existent_path, 'master')
+        assert error.type == SystemExit
+        assert error.value.code == 1
+
+    def test_wrong_dir_build(self, non_existent_path):
+        with pytest.raises(SystemExit) as error:
+            release_bot.fedpkg_build(non_existent_path, 'master')
+        assert error.type == SystemExit
+        assert error.value.code == 1
+
+    def test_wrong_dir_push(self, non_existent_path):
+        with pytest.raises(SystemExit) as error:
+            release_bot.fedpkg_push(non_existent_path, 'master')
+        assert error.type == SystemExit
+        assert error.value.code == 1
+
+    def test_wrong_dir_merge(self, non_existent_path):
+        with pytest.raises(SystemExit) as error:
+            release_bot.fedpkg_merge(non_existent_path, 'master')
+        assert error.type == SystemExit
+        assert error.value.code == 1
+
+    def test_wrong_dir_commit(self, non_existent_path):
+        with pytest.raises(SystemExit) as error:
+            release_bot.fedpkg_commit(non_existent_path, 'master', "Some message")
+        assert error.type == SystemExit
+        assert error.value.code == 1
+
+    def test_wrong_dir_sources(self, non_existent_path):
+        with pytest.raises(SystemExit) as error:
+            release_bot.fedpkg_sources(non_existent_path, 'master')
+        assert error.type == SystemExit
+        assert error.value.code == 1
+
+    def test_wrong_dir_spectool(self, non_existent_path):
+        with pytest.raises(SystemExit) as error:
+            release_bot.fedpkg_spectool(non_existent_path, 'master')
+        assert error.type == SystemExit
+        assert error.value.code == 1
+
+    def test_wrong_dir_lint(self, non_existent_path):
+        with pytest.raises(SystemExit) as error:
+            release_bot.fedpkg_lint(non_existent_path, 'master')
+        assert error.type == SystemExit
+        assert error.value.code == 1
+
+    def test_clone(self, tmp, package, fake_clone):
+        directory = release_bot.fedpkg_clone_repository(tmp, package)
+        assert os.path.isfile(os.path.join(directory, f"{package}.spec"))
+        assert os.path.isdir(os.path.join(directory, ".git"))
+
+    def test_switch_branch(self, fake_repository):
+        release_bot.fedpkg_switch_branch(fake_repository, "f28", False)
+        assert "f28" == self.run_cmd("git rev-parse --abbrev-ref HEAD", fake_repository).stdout.strip()
+        release_bot.fedpkg_switch_branch(fake_repository, "master", False)
+        assert "master" == self.run_cmd("git rev-parse --abbrev-ref HEAD", fake_repository).stdout.strip()
+
+    def test_commit(self, fake_repository):
+        spec_path = os.path.join(fake_repository, "example.spec")
+        with open(spec_path, "r+") as spec_file:
+            spec = spec_file.read() + "\n Test test"
+            spec_file.write(spec)
+
+        branch = "master"
+        commit_message = "Test commit"
+        assert release_bot.fedpkg_commit(fake_repository, "master", commit_message, False)
+        assert commit_message == self.run_cmd(f"git log -1 --pretty=%B {branch}| cat | head -n 1",
+                                              fake_repository).stdout.strip()
+
+    def test_lint(self, tmp, package, fake_clone):
+        directory = release_bot.fedpkg_clone_repository(tmp, package)
+        spec_path = os.path.join(directory, f"{package}.spec")
+        assert release_bot.fedpkg_lint(directory, "master", False)
+        with open(spec_path, "r+") as spec_file:
+            spec = spec_file.read() + "\n Test test"
+            spec_file.write(spec)
+            assert not release_bot.fedpkg_lint(directory, "master", False)
+
+    def test_sources(self, tmp, package, fake_clone):
+        directory = release_bot.fedpkg_clone_repository(tmp, package)
+        file_number = len(os.listdir(directory))
+        assert release_bot.fedpkg_sources(directory, "master", False)
+        assert file_number != len(os.listdir(directory))
+
+    def test_spectool(self, tmp, package, fake_clone):
+        directory = release_bot.fedpkg_clone_repository(tmp, package)
+        file_number = len(os.listdir(directory))
+        assert release_bot.fedpkg_spectool(directory, "master", False)
+        assert file_number != len(os.listdir(directory))
+
+    def test_workflow(self, fake_repository):
+        spec_path = os.path.join(fake_repository, "example.spec")
+        with open(spec_path, "r+") as spec_file:
+            spec = spec_file.read() + "\n Test test"
+            spec_file.write(spec)
+        commit_message = "Update"
+        assert release_bot.fedpkg_commit(fake_repository, "master", commit_message, False)
+        assert release_bot.fedpkg_switch_branch(fake_repository, "f28", False)
+        assert release_bot.fedpkg_merge(fake_repository, "f28", True, False)
+        assert commit_message == self.run_cmd(f"git log -1 --pretty=%B f28 | cat | head -n 1",
+                                              fake_repository).stdout.strip()
+
+    def test_update_package(self, no_build, no_push, no_sources, no_new_sources, fake_spectool,
+                            no_lint, new_release, fake_repository):
+        release_bot.CONFIGURATION['repository_name'] = 'example'
+        commit_message = f"Update to {new_release['version']}"
+        assert release_bot.update_package(fake_repository, "f28", new_release)
+        assert commit_message == self.run_cmd(f"git log -1 --pretty=%B | cat | head -n 1",
+                                              fake_repository).stdout.strip()
+
+    def test_release_in_fedora(self, no_build, no_push, no_sources, no_new_sources, fake_spectool,
+                               no_lint, fake_repository_clone, new_release, fake_tmp_clean):
+        release_bot.CONFIGURATION['repository_name'] = 'example'
+        release_bot.release_in_fedora(new_release)
+        commit_message = f"Update to {new_release['version']}"
+        assert commit_message == self.run_cmd(f"git log -1 --pretty=%B master| cat | head -n 1",
+                                              fake_repository_clone).stdout.strip()
+        assert commit_message == self.run_cmd(f"git log -1 --pretty=%B f28 | cat | head -n 1",
+                                              fake_repository_clone).stdout.strip()
+
+    def test_release_in_fedora_non_ff(self, no_build, no_push, no_sources, no_new_sources, no_lint,
+                                      fake_spectool, fake_repository_clone_no_ff, new_release, fake_tmp_clean):
+        release_bot.CONFIGURATION['repository_name'] = 'example'
+        release_bot.release_in_fedora(new_release)
+        commit_message = f"Update to {new_release['version']}"
+        assert commit_message == self.run_cmd(f"git log -1 --pretty=%B master| cat | head -n 1",
+                                              fake_repository_clone_no_ff).stdout.strip()
+        assert commit_message == self.run_cmd(f"git log -1 --pretty=%B f28 | cat | head -n 1",
+                                              fake_repository_clone_no_ff).stdout.strip()

--- a/tests/test_load_release_conf.py
+++ b/tests/test_load_release_conf.py
@@ -9,7 +9,7 @@ class TestLoadReleaseConf:
         """ setup any state tied to the execution of the given method in a
         class.  setup_method is invoked for every test method of a class.
         """
-        release_bot.CONFIGURATION['logger'] = release_bot.set_logging(level=70)
+        release_bot.CONFIGURATION['logger'] = release_bot.set_logging(level=10)
         release_bot.CONFIGURATION['debug'] = True
 
     def teardown_method(self, method):

--- a/tests/test_pypi_2.py
+++ b/tests/test_pypi_2.py
@@ -14,7 +14,7 @@ class TestPypi:
         """ setup any state tied to the execution of the given method in a
         class.  setup_method is invoked for every test method of a class.
         """
-        release_bot.CONFIGURATION['logger'] = release_bot.set_logging(level=70)
+        release_bot.CONFIGURATION['logger'] = release_bot.set_logging(level=10)
         release_bot.CONFIGURATION['debug'] = True
 
     def teardown_method(self, method):

--- a/tests/test_pypi_3.py
+++ b/tests/test_pypi_3.py
@@ -14,7 +14,7 @@ class TestPypi:
         """ setup any state tied to the execution of the given method in a
         class.  setup_method is invoked for every test method of a class.
         """
-        release_bot.CONFIGURATION['logger'] = release_bot.set_logging(level=70)
+        release_bot.CONFIGURATION['logger'] = release_bot.set_logging(level=10)
         release_bot.CONFIGURATION['debug'] = True
 
     def teardown_method(self, method):
@@ -84,7 +84,7 @@ class TestPypi:
         release_bot.pypi_build_wheel(package_setup, 3)
         assert glob.glob(os.path.join(package_setup, 'dist/rlsbot_test-1.0.0-py3*.whl'))
 
-    @pytest.mark.skipif(os.environ['TRAVIS_PYTHON_VERSION'], reason="travis doesn't allow installs")
+    @pytest.mark.skipif('TRAVIS_PYTHON_VERSION' in os.environ, reason="travis doesn't allow installs")
     def test_install_3(self, package_setup):
         release_bot.pypi_build_sdist(package_setup)
         release_bot.pypi_build_wheel(package_setup, 3)
@@ -94,7 +94,7 @@ class TestPypi:
         assert self.run_cmd(f'pip3 show rlsbot-test', package_setup).returncode == 0
         assert self.run_cmd(f'$HOME/.local/bin/rlsbot-test', package_setup).returncode == 0
 
-    @pytest.mark.skipif(os.environ['TRAVIS_PYTHON_VERSION'], reason="travis doesn't allow installs")
+    @pytest.mark.skipif('TRAVIS_PYTHON_VERSION' in os.environ, reason="travis doesn't allow installs")
     def test_release_3(self, minimal_conf_array, package_setup, no_upload):
         minimal_conf_array['fs_path'] = package_setup
         release_bot.release_on_pypi(minimal_conf_array)

--- a/tests/test_specfile.py
+++ b/tests/test_specfile.py
@@ -22,7 +22,7 @@ class TestSpecFile:
         """ setup any state tied to the execution of the given method in a
         class.  setup_method is invoked for every test method of a class.
         """
-        release_bot.CONFIGURATION['logger'] = release_bot.set_logging(level=70)
+        release_bot.CONFIGURATION['logger'] = release_bot.set_logging(level=10)
         release_bot.CONFIGURATION['debug'] = True
 
     def teardown_method(self, method):


### PR DESCRIPTION
This fixes #23 as it adds tests for Fedora and also a Dockerfile for testing in Fedora environment in Travis. It also changes the structure of Fedora-related functionality, mainly it was rewritten into more functions to provide the ability to mock them.